### PR TITLE
Moved relative references from root to working folder

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
         <div class='row'>
           <div class='col-md-8'>
             <div id='logo'>
-              <a href='/'><img class='img-responsive' src='/images/logo.png' alt='Macoupin Budget' /></a>
+              <a href='/'><img class='img-responsive' src='images/logo.png' alt='Macoupin Budget' /></a>
             </div>
             <p>Explore the Macoupin County, IL budget from 1995 to 2015 and learn how the money is being spent.</p>
           </div>
           <div class='col-md-4'>
-            <img id='credit' class='pull-right' class='img-responsive' src='/images/pete_duncan.png' alt='Compiled by: Pete Duncan Macoupin County Clerk' />
+            <img id='credit' class='pull-right' class='img-responsive' src='images/pete_duncan.png' alt='Compiled by: Pete Duncan Macoupin County Clerk' />
           </div>
         </div>
       </div>

--- a/js/app.js
+++ b/js/app.js
@@ -8,7 +8,7 @@
         }
 
         if ( ! template_cache.tmpl_cache[tmpl_name] ) {
-            var tmpl_dir = '/js/views';
+            var tmpl_dir = 'js/views';
             var tmpl_url = tmpl_dir + '/' + tmpl_name + '.html?4';
 
             var tmpl_string;
@@ -221,7 +221,7 @@
         bootstrap: function(init, year){
             var self = this;
             this.spin('#main-chart', 'large');
-            $.when($.get('/data/macoupin-budget_1997-2014.csv')).then(
+            $.when($.get('data/macoupin-budget_1997-2014.csv')).then(
                 function(data){
                     var json = $.csv.toObjects(data);
                     var loadit = []


### PR DESCRIPTION
When hosting the application in a sub-folder rather than root, several relative references were breaking.  
These references were pointing to the root folder instead of a the working folder. Changing to working folder references fixes this.  
Used no slash style instead of dot-slash style since this is the style used in other parts of the application.
